### PR TITLE
Add baseline test suite, pytest/pyrefly CI, grouped Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,5 +6,10 @@ updates:
       interval: "weekly"
       day: "tuesday"
     target-branch: "develop"
+    groups:
+      patch-and-minor:
+        update-types:
+          - "minor"
+          - "patch"
     labels:
       - "dependencies"

--- a/.github/workflows/pyrefly.yml
+++ b/.github/workflows/pyrefly.yml
@@ -1,0 +1,23 @@
+name: pyrefly
+on: push
+
+jobs:
+  pyrefly:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          python-version: "3.13"
+
+      - name: Install packages
+        run: uv sync --all-extras --dev
+
+      - name: Run pyrefly
+        run: uv run pyrefly check

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,25 @@
+name: PyTest
+on: push
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          python-version: "3.13"
+
+      - name: Install packages
+        run: uv sync --all-extras --dev
+
+      - name: Run tests
+        run: uv run pytest tests
+        env:
+          CI: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,8 @@ dev = [
     "ruff>=0.9.0",
     "pyrefly>=1.1.1",
     "pre-commit>=4.2.0,<5",
+    "pytest>=8.0.0",
+    "pytest-asyncio>=0.24.0",
 ]
 
 [build-system]
@@ -35,3 +37,6 @@ select = ["E", "F", "W", "I", "UP", "G"]
 
 [tool.pyrefly]
 python-version = "3.11"
+
+[tool.pytest.ini_options]
+asyncio_mode = "strict"

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,0 +1,24 @@
+"""Smoke tests: import every public module and instantiate the driver class without
+hardware, asserting it advertises the interfaces it claims.
+
+No motor is involved: ZaberDriver only stores configuration, and the serial connection
+is opened lazily inside each operation.
+"""
+
+from pyobs.interfaces import IMode, IMotion
+from pyobs.modules import Module
+
+from pyobs_zaber import ZaberModeSelector
+
+
+def test_import_driver_module() -> None:
+    from pyobs_zaber import zaberdriver  # noqa: F401
+
+    assert zaberdriver.ZaberDriver is not None
+
+
+def test_instantiate_mode_selector() -> None:
+    selector = ZaberModeSelector(modes={"spec": 100.0, "phot": 200.0})
+    assert isinstance(selector, Module)
+    assert isinstance(selector, IMode)
+    assert isinstance(selector, IMotion)

--- a/tests/test_zaberdriver.py
+++ b/tests/test_zaberdriver.py
@@ -1,0 +1,42 @@
+"""Unit tests for the non-hardware logic in ZaberDriver."""
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from zaber_motion import Units
+
+from pyobs_zaber.zaberdriver import ZaberDriver
+
+
+def test_constructor_defaults() -> None:
+    driver = ZaberDriver()
+    assert driver.port == "/dev/ttyUSB1"
+    assert driver.speed == 10000
+    assert driver.acceleration == 800
+    assert driver.length_unit is Units.ANGLE_DEGREES
+    assert driver.system_led is False
+
+
+@pytest.mark.asyncio
+async def test_move_by_defaults_to_configured_speed(monkeypatch: pytest.MonkeyPatch) -> None:
+    axis = MagicMock()
+    axis.move_relative_async = AsyncMock()
+
+    @asynccontextmanager
+    async def fake_axis(port):
+        yield axis
+
+    monkeypatch.setattr("pyobs_zaber.zaberdriver.zaber_axis", fake_axis)
+
+    driver = ZaberDriver(speed=12345)
+    await driver.move_by(1.0)
+
+    axis.move_relative_async.assert_awaited_once_with(
+        1.0,
+        driver.length_unit,
+        velocity=12345,
+        velocity_unit=driver.speed_unit,
+        acceleration=driver.acceleration,
+        acceleration_unit=driver.acceleration_unit,
+    )

--- a/tests/test_zabermodeselector.py
+++ b/tests/test_zabermodeselector.py
@@ -1,0 +1,52 @@
+"""Unit tests for the mode-selection state logic in ZaberModeSelector.
+
+Movement itself is hardware I/O and is mocked out; these cover mode validation,
+short-circuiting, and position mapping.
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from pyobs_zaber import ZaberModeSelector
+
+_MODES = {"spec": 100.0, "phot": 200.0}
+
+
+def _make_selector() -> tuple[ZaberModeSelector, AsyncMock]:
+    selector = ZaberModeSelector(modes=_MODES)
+    move_to = AsyncMock()
+    selector.driver.move_to = move_to  # type: ignore[method-assign]
+    return selector, move_to
+
+
+def test_constructor_stores_modes_and_driver() -> None:
+    selector = ZaberModeSelector(modes=_MODES)
+    assert selector.modes == _MODES
+    assert selector.current_mode == "undefined"
+
+
+@pytest.mark.asyncio
+async def test_set_mode_moves_to_position() -> None:
+    selector, move_to = _make_selector()
+    await selector.set_mode("phot")
+    move_to.assert_awaited_once_with(200.0)
+    assert selector.current_mode == "phot"
+
+
+@pytest.mark.asyncio
+async def test_set_mode_unknown_mode_is_ignored() -> None:
+    selector, move_to = _make_selector()
+    await selector.set_mode("nope")
+    move_to.assert_not_awaited()
+    assert selector.current_mode == "undefined"
+
+
+@pytest.mark.asyncio
+async def test_set_mode_same_mode_is_noop() -> None:
+    selector, move_to = _make_selector()
+    await selector.set_mode("spec")
+    move_to.reset_mock()
+    await selector.set_mode("spec")
+    move_to.assert_not_awaited()
+    assert selector.current_mode == "spec"

--- a/uv.lock
+++ b/uv.lock
@@ -866,6 +866,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "invoke"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1438,6 +1447,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "pre-commit"
 version = "4.6.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1854,6 +1872,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
 name = "pynacl"
 version = "1.6.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1941,6 +1968,8 @@ dev = [
     { name = "black" },
     { name = "pre-commit" },
     { name = "pyrefly" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "ruff" },
 ]
 
@@ -1955,6 +1984,8 @@ dev = [
     { name = "black", specifier = ">=25.1.0,<27" },
     { name = "pre-commit", specifier = ">=4.2.0,<5" },
     { name = "pyrefly", specifier = ">=1.1.1" },
+    { name = "pytest", specifier = ">=8.0.0" },
+    { name = "pytest-asyncio", specifier = ">=0.24.0" },
     { name = "ruff", specifier = ">=0.9.0" },
 ]
 
@@ -1975,6 +2006,35 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0f/06/810d31380f66c75e1c0779a408d3b16117b1b368b57894f6aa66bef21686/pyrefly-1.2.0-py3-none-win32.whl", hash = "sha256:8c90751de8506d938e8f802659c74cf35bd7a0036510ee6c634a38eebb280bfa", size = 13229447, upload-time = "2026-08-01T02:56:20.921Z" },
     { url = "https://files.pythonhosted.org/packages/ed/98/4dafa3c7a1caed2dc8cc708dde09ba27963c7736508f55b626fff3024113/pyrefly-1.2.0-py3-none-win_amd64.whl", hash = "sha256:8a8964c224ccc4882730130955815de21ff443c1ac3f0b90685b19bf63848170", size = 14087387, upload-time = "2026-08-01T02:56:23.188Z" },
     { url = "https://files.pythonhosted.org/packages/1b/1c/df3cb0a2e5591660ded7a1836cd2f29dc48c91adb1c0a3a700a96f6d09e1/pyrefly-1.2.0-py3-none-win_arm64.whl", hash = "sha256:3a90bb8df39dfbac74b1f3b2e9d7c526b8f80568884c3944d955023a73ebf61e", size = 13430873, upload-time = "2026-08-01T02:56:25.425Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Part of pyobs-core#752 (core-tier test baseline + Dependabot auto-merge). Fourth repo in the rollout order.

**What's here**
- `tests/test_import.py`: import every public module + instantiate `ZaberModeSelector`, assert `IMode`/`IMotion`.
- `tests/test_zaberdriver.py`: constructor defaults and `move_by` speed fallback (serial mocked).
- `tests/test_zabermodeselector.py`: mode validation/short-circuit and position mapping, movement mocked.
- `pytest` + `pytest-asyncio` in dev deps, `pytest.yml` + `pyrefly.yml` workflows, Dependabot patch/minor grouping.

Local checks: `uv run pytest tests` (8 passed), `ruff check`, `pyrefly check`, `black --check` all green.